### PR TITLE
Update atomport-private.c

### DIFF
--- a/src/atomport-private.c
+++ b/src/atomport-private.c
@@ -12,6 +12,10 @@
  */
 void avrInitSystemTickTimer ( void )
 {
+    TCCR1A &= 0xFC;     // Clear WGM11 and WGM10
+    TCCR1B &= 0xC0;     // Clear TCCR1B prescaler and mode bits
+    TCNT1  = 0;         // Start counter at 0
+    
     /* Set timer 1 compare match value for configured system tick,
      * with a prescaler of 256. We will get a compare match 1A
      * interrupt on every system tick, in which we must call the


### PR DESCRIPTION
When I ran this on a Arduino UNO, the tick interval was wrong.  Examining the registers revealed that WGM10 in TCCR1A was already set - this set timer 1 to mode Fast PWM 8-bit. I added lines to set the pertinent bits in TCCR1x registers to known values and now the tick is right. Before this change the tick was running at about 400ms instead of the intended 1000ms.